### PR TITLE
feat: Allow running without a file system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows"
     ]
 dependencies = [
-    "pytket >=1.30",
+    "pytket >=1.33",
     "pytket-phir >=0.8.0",
     "quantum-pecos[simulators,wasmtime] >=0.6.0.dev3"
     ]

--- a/src/pytket_pecos/emulator.py
+++ b/src/pytket_pecos/emulator.py
@@ -6,7 +6,7 @@ from pecos.foreign_objects.wasmtime import WasmtimeObj
 from pytket.circuit import Circuit
 from pytket.phir.api import pytket_to_phir
 from pytket.utils.outcomearray import OutcomeArray
-from pytket.wasm import WasmFileHandler
+from pytket.wasm.wasm import WasmModuleHandler
 
 
 def is_reglike(units):
@@ -22,7 +22,7 @@ class Emulator:
     def __init__(
         self,
         circuit: Circuit,
-        wasm: Optional[WasmFileHandler] = None,
+        wasm: Optional[WasmModuleHandler] = None,
         error_model: Optional[ErrorModel] = None,
         qsim: str = "stabilizer",
         seed: Optional[int] = None,
@@ -31,7 +31,7 @@ class Emulator:
             raise ValueError("Circuit contains units that do not belong to a register.")
 
         self.phir = pytket_to_phir(circuit)
-        self.foreign_object = None if wasm is None else WasmtimeObj(wasm._wasm_file)
+        self.foreign_object = None if wasm is None else WasmtimeObj(wasm.bytecode())
         self.engine = HybridEngine(qsim=qsim, error_model=error_model)
         self.engine.use_seed(seed)
 


### PR DESCRIPTION
Replaces WasmFileHandler with WasmModuleHandler that allows pytket-pecos to be run in contexts that do not have access to a file system.

Bumps minimum pytket version to 1.33 to access this feature.

WasmModuleHandler is a subclass of WasmFileHandler so this should be a non-breaking change for the external API.