### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'macos-13', 'windows-latest']
-        pyver: ['3.10', '3.11', '3.12']
+        pyver: ['3.10', '3.11', '3.12', '3.13']
     runs-on:
       ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ circuits using the
 
 ## Installation
 
-Installation requires Python 3.10, 3.11 or 3.12. Linux, MacOS and Windows are
-all supported.
+Installation requires Python 3.10, 3.11, 3.12 or 3.13. Linux, MacOS and Windows
+are all supported.
 
 ### From pypi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,9 @@ classifiers = [
     "Operating System :: Microsoft :: Windows"
     ]
 dependencies = [
-    "projectq >=0.8.0",
     "pytket >=1.36",
     "pytket-phir >=0.9.1",
-    "quantum-pecos[simulators,wasmtime] >=0.6.0.dev7"
+    "quantum-pecos[projectq,wasmtime] >=0.6.0.dev7"
     ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows"
     ]
 dependencies = [
+    "projectq >=0.8.0",
     "pytket >=1.36",
     "pytket-phir >=0.9.1",
     "quantum-pecos[simulators,wasmtime] >=0.6.0.dev7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "pytket_pecos"
-version = "0.1.31"
+version = "0.1.32"
 description = "This package enables emulation of pytket circuits using the PECOS emulator."
 authors = [{name = "Alec Edgington", email = "alec.edgington@quantinuum.com"}]
 license = {file = "LICENSE"}
@@ -18,9 +18,9 @@ classifiers = [
     "Operating System :: Microsoft :: Windows"
     ]
 dependencies = [
-    "pytket >=1.34",
-    "pytket-phir >=0.9.0",
-    "quantum-pecos[simulators,wasmtime] >=0.6.0.dev6"
+    "pytket >=1.36",
+    "pytket-phir >=0.9.1",
+    "quantum-pecos[simulators,wasmtime] >=0.6.0.dev7"
     ]
 
 [project.urls]


### PR DESCRIPTION
It seems that with pecos 0.6.0.dev7 we now need to add the projectq dependency explicitly.

Silver lining: we can now support Python 3.13.