### PR TITLE
Revert quantum-pecos update; bump version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "pytket_pecos"
-version = "0.2.1"
+version = "0.2.2"
 description = "This package enables emulation of pytket circuits using the PECOS emulator."
 authors = [{name = "Alec Edgington", email = "alec.edgington@quantinuum.com"}]
 license = {file = "LICENSE"}
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "pytket >=2.9.1",
     "pytket-phir >=0.10.0",
-    "quantum-pecos[projectq,wasmtime] >=0.7.0.dev0"
+    "quantum-pecos[projectq,wasmtime] ==0.6.0.dev8"
     ]
 
 [project.urls]

--- a/src/pytket_pecos/emulator.py
+++ b/src/pytket_pecos/emulator.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
 
 from pecos.engines.hybrid_engine import HybridEngine  # type: ignore
+from pecos.error_models.error_model_abc import ErrorModel  # type: ignore
 from pecos.foreign_objects.wasmtime import WasmtimeObj
-from pecos.protocols import ErrorModelProtocol  # type: ignore
 from pytket.circuit import Circuit
 from pytket.phir.api import pytket_to_phir
 from pytket.utils.outcomearray import OutcomeArray
@@ -23,7 +23,7 @@ class Emulator:
         self,
         circuit: Circuit,
         wasm: WasmModuleHandler | None = None,
-        error_model: ErrorModelProtocol | None = None,
+        error_model: ErrorModel | None = None,
         qsim: str = "stabilizer",
         seed: int | None = None,
     ):


### PR DESCRIPTION
Due to https://github.com/CQCL/pytket-quantinuum/issues/625 .