### PR TITLE
Fix PECOS repository link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This package enables emulation of [pytket](https://github.com/CQCL/tket)
 circuits using the
-[PECOS](https://github.com/PECOS-packages/PECOS/tree/development) emulator.
+[PECOS](https://github.com/PECOS-packages/PECOS) emulator.
 
 ## Installation
 


### PR DESCRIPTION
The link to the PECOS repository ended in `/tree/development` after the repository URL, but it looks like the main branch for the repo is now named `dev`.

To make this link less susceptible to changes like that, this commit removes the `/tree/development` part so it just links to the repo.